### PR TITLE
Nuevo campo para evitar enviar el mismo correo varias veces a un cliente con varios contratos

### DIFF
--- a/poweremail_campaign/poweremail_campaign.py
+++ b/poweremail_campaign/poweremail_campaign.py
@@ -23,7 +23,8 @@ class PoweremailCampaign(osv.osv):
             for line in campanya.reference_ids:
                 if line.mail_id:
                     created.append(line.id)
-                total.append(line.id)
+                if line.state != 'avoid_duplicate':
+                    total.append(line.id)
             if not total:
                 res[campanya.id] = 0.0
             else:
@@ -43,7 +44,8 @@ class PoweremailCampaign(osv.osv):
             for line in campanya.reference_ids:
                 if line.state == 'sent':
                     sent.append(line.id)
-                total.append(line.id)
+                if line.state != 'avoid_duplicate':
+                    total.append(line.id)
             if not total:
                 res[campanya.id] = 0.0
             else:

--- a/poweremail_campaign/poweremail_campaign_line.py
+++ b/poweremail_campaign/poweremail_campaign_line.py
@@ -105,7 +105,8 @@ class PoweremailCampaignLine(osv.osv):
     STATE_SELECTION = [('to_send', 'To Send'),
                        ('sending', 'Sending'),
                        ('sending_error', 'Sending Error'),
-                       ('sent', 'Sent')]
+                       ('sent', 'Sent'),
+                       ('avoid_duplicate', 'Avoid Duplicate')]
 
     _rec_name = 'campaign_id'
 

--- a/poweremail_campaign/poweremail_campaign_view.xml
+++ b/poweremail_campaign/poweremail_campaign_view.xml
@@ -42,6 +42,7 @@
                     </group>
                     <group colspan="8" col="8">
                         <field name="batch"/>
+                        <field name="distinct_mails"/>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
## Objetivos

- Hacer que cuando un cliente tenga dos o más contratos, solo reciba una única vez el mismo correo de la misma campaña. Para ello, hay que activar el check 'Avoid same email' y actualizar las líneas de la campaña antes de enviar los emails
![imagen](https://user-images.githubusercontent.com/83698096/163207633-b72265ed-7b0b-4132-b93d-9c39833b7feb.png)



## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - poweremail_campaign


## Checklist

- [x] Test code