### PR TITLE
fix vista poweremail campaign

### DIFF
--- a/poweremail_campaign/poweremail_campaign_view.xml
+++ b/poweremail_campaign/poweremail_campaign_view.xml
@@ -15,10 +15,10 @@
                         <field name="template_obj" colspan="2"/>
                     </group>
                     <group colspan="20" col="20">
-                        <group colspan="19" string="Filter Objects" col="1">
+                        <group colspan="20" string="Filter Objects" col="1">
                             <field name="domain" colspan="19" nolabel="1"/>
                         </group>
-                        <group colspan="1" string="Help" col="1">
+                        <group colspan="20" string="Help" col="1" expand="1">
                             <label align="0.0" string="The domain has to be a list of tuples"/>
                             <label align="0.0" string="with conditions, refeering the atributtes."/>
                             <label align="0.0" string="For example, if we want to search a"/>


### PR DESCRIPTION
## Objetivos

- Corregir vista poweremail campaign

## Comportamiento antiguo

- Aparecían cosas fuera de sitio en la vista

## Comportamiento nuevo

- Se ha corregido la vista poweremail campaign para que se vea adecuadamente

## Afectaciones / Migración de datos

- [ ] Código. Reiniciar servicios
- [ ] Actualización módulos:
    - poweremail_campaign

