### PR TITLE
Al enviar email signaturit poder asignar por variable de configuración el tipo de request

### DIFF
--- a/poweremail_signaturit/migrations/5.0.23.6.0/post-001_add_var_conf_request_type.py
+++ b/poweremail_signaturit/migrations/5.0.23.6.0/post-001_add_var_conf_request_type.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info("Updating XML")
+    record_id = "signaturit_email_request_type"
+    load_data_records(
+        cursor, 'poweremail_signaturit', "poweremail_mailbox_data.xml", [record_id], mode='update'
+    )
+    logger.info("XML succesfully updatded")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_signaturit/poweremail_core.py
+++ b/poweremail_signaturit/poweremail_core.py
@@ -88,7 +88,8 @@ class PoweremailCore(osv.osv):
                 })
 
         # Certified email type
-        params['type'] = "open_document"
+        request_type = self.pool.get("res.config").get(cr, uid, "signaturit_email_request_type", "open_document")
+        params['type'] = request_type
 
         # Attachments
         documents = []

--- a/poweremail_signaturit/poweremail_mailbox_data.xml
+++ b/poweremail_signaturit/poweremail_mailbox_data.xml
@@ -15,5 +15,21 @@
 * document_downloaded - The document has been downloaded.
 </field>
         </record>
+        <record model="res.config" id="signaturit_email_request_type" forcecreate="1">
+          <field name="name">signaturit_email_request_type</field>
+          <field name="value">open_document</field>
+          <field name="description">
+              Defineix el tipus de solicitud d'email que s'enviara a signaturit.
+              Depenent tipus que escollim el client veure el email en un format diferent.
+              Opcions posibles:
+              * delivery - Send the email as it is certifying the delivery process.
+              * open_document -
+                 Send a modified version of the email with a button that redirects the user to our platform to open the PDF attachments.
+                 With this method, you can track when the user opens the attached files.
+                 Note: This method only supports PDF documents to be attached.
+              * open_every_document - This type works like the open_document type but allows to track the opening of every PDF file in emails with multiple attachments.
+              * open_email - With this method, you can track when the user opens the email.
+          </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Se ha creado una variable de configuración `signaturit_email_request_type` donde se puede especificar el tipo de request a utilizar al crear un request de email a signaturit. Hasta ahora siempre se usaba el tipo `open_document`

Los posibles valores son:

 * delivery - Send the email as it is certifying the delivery process.
 * open_document - Send a modified version of the email with a button that redirects the user to our platform to open the PDF attachments
* open_every_document - This type works like the open_document type but allows to track the opening of every PDF file in emails with multiple attachments.
 * open_email - With this method, you can track when the user opens the email.
 
Más info: https://docs.signaturit.com/api/latest#emails_create_email