### PR TITLE
Añadir nuevo modulo para cargar las plantillas de poweremail usando un asistente

### DIFF
--- a/poweremail_load_templates/__init__.py
+++ b/poweremail_load_templates/__init__.py
@@ -1,0 +1,3 @@
+from . import wizard
+from . import poweremail_template
+from . import poweremail_templates_source

--- a/poweremail_load_templates/__terp__.py
+++ b/poweremail_load_templates/__terp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+  "name": "PowerEmail Campaign",
+  "description": """PowerEmail Sync Templates""",
+  "version": "0-dev",
+  "author": "GISCE",
+  "category": "GISCEMaster",
+  "depends": [
+      "poweremail",
+  ],
+  "init_xml": [],
+  "demo_xml": [],
+  "update_xml": [
+      "poweremail_template_view.xml",
+      "poweremail_templates_source_view.xml",
+      "wizard/wizard_load_poweremail_template.xml",
+      "security/ir.model.access.csv",
+  ],
+  "active": False,
+  "installable": True
+}

--- a/poweremail_load_templates/migrations/5.0.23.9.0/post-0001-poweremail-load-templates.py
+++ b/poweremail_load_templates/migrations/5.0.23.9.0/post-0001-poweremail-load-templates.py
@@ -1,0 +1,73 @@
+import logging
+import pooler
+from oopgrade.oopgrade import load_data_records
+from oopgrade.oopgrade import load_data
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+    pool = pooler.get_pool(cursor.dbname)
+
+    logger.info('Adding poweremail templates source to module')
+    pool.get("poweremail.templates.source")._auto_init(cursor, context={
+        'module': 'poweremail_load_templates'
+    })
+
+    logger.info('Adding poweremail templates to module')
+    pool.get("poweremail.templates")._auto_init(cursor, context={
+        'module': 'poweremail_load_templates'
+    })
+
+    logger.info('Adding wizard to module')
+    pool.get("wizard.load.poweremail.template")._auto_init(cursor, context={
+        'module': 'poweremail_load_templates'
+    })
+
+    logger.info('Adding poweremail templates source view')
+    load = [
+        'poweremail_templates_source_tree',
+        'poweremail_templates_source_form'
+    ]
+    load_data_records(
+        cursor, 'poweremail_load_templates',
+        'poweremail_templates_source_view.xml', load
+    )
+
+    logger.info('Adding poweremail templates view')
+    load = [
+        'view_poweremail_source_form'
+    ]
+    load_data_records(
+        cursor, 'poweremail_load_templates',
+        'poweremail_template_view.xml', load
+    )
+
+    logger.info('Adding poweremail templates source view')
+    load = [
+        'view_wizard_load_poweremail_template',
+        'action_wizard_load_poweremail_template',
+        'values_wizard_load_poweremail_template'
+    ]
+    load_data_records(
+        cursor, 'poweremail_load_templates',
+        'wizard/wizard_load_poweremail_template.xml', load
+    )
+
+    logger.info('XML refreshed for poweremail_templates_source.')
+
+    logger.info("Updating access CSV")
+    load_data(
+        cursor, 'poweremail_load_templates',
+        'security/ir.model.access.csv', idref=None,
+        mode='update'
+    )
+    logger.info("CSV succesfully updated.")
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_load_templates/poweremail_template.py
+++ b/poweremail_load_templates/poweremail_template.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-The entered file does not exist
+from osv import osv, fields
+
+
+class poweremail_templates(osv.osv):
+
+    _name = "poweremail.templates"
+    _inherit = "poweremail.templates"
+    _columns = {
+        'source_ids': fields.one2many(
+            'poweremail.templates.source', 'template_id', 'Sources'
+        )
+    }
+
+
+poweremail_templates()

--- a/poweremail_load_templates/poweremail_template_view.xml
+++ b/poweremail_load_templates/poweremail_template_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_poweremail_source_form">
+            <field name="name">poweremail.templates.form</field>
+            <field name="model">poweremail.templates</field>
+            <field name="inherit_id" ref="poweremail.poweremail_template_form"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Advanced']" position="after">
+                    <page string="Source">
+                         <field name="source_ids" colspan="2"/>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_load_templates/poweremail_templates_source.py
+++ b/poweremail_load_templates/poweremail_templates_source.py
@@ -10,7 +10,7 @@ class PoweremailTemplatesSource(osv.osv):
         'template_id': fields.many2one(
             'poweremail.templates', 'Template', select=1, required=True
         ),
-        'source': fields.char('Source', size=64, required=True),
+        'source': fields.char('Source', size=256, required=True),
         'lang': fields.many2one(
             'res.lang', 'Language', select=1, required=True
         ),

--- a/poweremail_load_templates/poweremail_templates_source.py
+++ b/poweremail_load_templates/poweremail_templates_source.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+
+
+class PoweremailTemplatesSource(osv.osv):
+
+    _name = "poweremail.templates.source"
+    _description = "Poweremail templates source"
+    _columns = {
+        'template_id': fields.many2one(
+            'poweremail.templates', 'Template', select=1, required=True
+        ),
+        'source': fields.char('Source', size=64, required=True),
+        'lang': fields.many2one(
+            'res.lang', 'Language', select=1, required=True
+        ),
+    }
+
+
+PoweremailTemplatesSource()

--- a/poweremail_load_templates/poweremail_templates_source_view.xml
+++ b/poweremail_load_templates/poweremail_templates_source_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="poweremail_templates_source_tree">
+            <field name="name">poweremail.templates.source.tree</field>
+            <field name="model">poweremail.templates.source</field>
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                <tree string="Power Email Templates Source">
+                    <field name="template_id" select="1"/>
+                    <field name="lang" select="1"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="poweremail_templates_source_form">
+            <field name="name">poweremail.templates.source.form</field>
+            <field name="model">poweremail.templates.source</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Power Email Templates Source">
+                    <field name="template_id" colspan="4" required="1"/>
+                    <field name="source" colspan="2" required="1"/>
+                    <field name="lang" colspan="2" widget="selection" required="1"/>
+                </form>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_load_templates/security/ir.model.access.csv
+++ b/poweremail_load_templates/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_wizard_load_poweremail_template_r","wizard.load.poweremail.template","model_wizard_load_poweremail_template","poweremail.res_groups_peuserse",1,0,0,0
+"access_wizard_load_poweremail_template_w","wizard.load.poweremail.template","model_wizard_load_poweremail_template","poweremail.res_groups_peusersi",1,1,1,0
+"access_wizard_load_poweremail_template_u","wizard.load.poweremail.template","model_wizard_load_poweremail_template","poweremail.res_groups_pemanager",1,1,1,1

--- a/poweremail_load_templates/tests/__init__.py
+++ b/poweremail_load_templates/tests/__init__.py
@@ -1,0 +1,1 @@
+from test_wizard_load_poweremail_template import *

--- a/poweremail_load_templates/tests/test_files/test_file_1.mako
+++ b/poweremail_load_templates/tests/test_files/test_file_1.mako
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+    <head></head>
+    <body>
+        Test File 1
+    </body>
+</html>

--- a/poweremail_load_templates/tests/test_wizard_load_poweremail_template.py
+++ b/poweremail_load_templates/tests/test_wizard_load_poweremail_template.py
@@ -1,0 +1,71 @@
+
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from dateutil.relativedelta import relativedelta
+from destral import testing
+from destral.transaction import Transaction
+from datetime import datetime
+import calendar
+from osv import osv
+
+
+class TestLoadTemplate(testing.OOTestCase):
+    def setUp(self):
+        self.pool = self.openerp.pool
+
+    def test_load_poweremail_template(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            context = {}
+
+            # Objects
+            imd_obj = self.pool.get('ir.model.data')
+            poweremail_template_obj = self.pool.get('poweremail.templates')
+            poweremail_template_source_obj = self.pool.get(
+                'poweremail.templates.source'
+            )
+            wiz = self.openerp.pool.get('wizard.load.poweremail.template')
+
+            # Get initial body text
+            poweremail_template_id = imd_obj.get_object_reference(
+                cursor, uid, 'poweremail', 'default_template_poweremail'
+            )[1]
+
+            poweremail_template_v = poweremail_template_obj.read(
+                cursor, uid, poweremail_template_id, [
+                    'def_body_text'
+                ],
+                context=context
+            )
+
+            initial_body_text = poweremail_template_v['def_body_text']
+
+            # Create Template Source
+            poweremail_template_source_obj.create(
+                cursor, uid, {
+                    'template_id': poweremail_template_id,
+                    'source': 'poweremail_load_templates/tests/test_files/test_file_1.mako',
+                    'lang': 1,
+                },
+                context=context
+            )
+
+            # Call wizard function
+            wiz.load_poweremail_template(
+                cursor, uid, [poweremail_template_id], context=context
+            )
+
+            # Get new body text
+            poweremail_template_v = poweremail_template_obj.read(
+                cursor, uid, poweremail_template_id, [
+                    'def_body_text'
+                ],
+                context=context
+            )
+
+            new_body_text = poweremail_template_v['def_body_text']
+
+            # Check if new and intial are different
+            self.assertNotEqual(initial_body_text, new_body_text)

--- a/poweremail_load_templates/wizard/__init__.py
+++ b/poweremail_load_templates/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_load_poweremail_template

--- a/poweremail_load_templates/wizard/wizard_load_poweremail_template.py
+++ b/poweremail_load_templates/wizard/wizard_load_poweremail_template.py
@@ -11,43 +11,16 @@ class WizardLoadPoweremailTemplate(osv.osv_memory):
         if context is None:
             context = {}
         wiz = self.browse(cursor, uid, ids[0], context=context)
-        poweremail_template_obj = self.pool.get('poweremail.templates')
-        poweremail_template_source_obj = self.pool.get(
-            'poweremail.templates.source'
-        )
-        res_lang_obj = self.pool.get('res.lang')
-        # Read source ids
-        source_v = poweremail_template_obj.read(
-            cursor, uid, ids[0], ['source_ids'], context=context
-        )
-        source_ids = source_v['source_ids']
-        for source_id in source_ids:
-            template_source_v = poweremail_template_source_obj.read(
-                cursor, uid, source_id, [
-                    'template_id', 'source', 'lang'
-                ],
-                context=context
-            )
+        for source in wiz.template_id.source_ids:
             file_path = "{}/{}".format(
-                config['addons_path'], template_source_v['source']
+                config['addons_path'], source.source
             )
             if os.path.exists(file_path):
                 with open(file_path, "r") as mf:
                     ctx = context.copy()
-                    res_lang_v = res_lang_obj.read(
-                        cursor, uid, template_source_v['lang'][0], [
-                            'code'
-                        ],
-                        context=context
-                    )
-                    ctx['lang'] = res_lang_v['code']
+                    ctx['lang'] = source.lang.code
                     file_contents = mf.read()
-                    poweremail_template_obj.write(
-                        cursor, uid, template_source_v['template_id'][0], {
-                            'def_body_text': file_contents
-                        },
-                        context=ctx
-                    )
+                    wiz.template_id.write({'def_body_text': file_contents}, context=ctx)
             else:
                 path_split = file_path.split('/')
                 raise osv.except_osv(

--- a/poweremail_load_templates/wizard/wizard_load_poweremail_template.py
+++ b/poweremail_load_templates/wizard/wizard_load_poweremail_template.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from osv import fields, osv
+from tools import config
+import os
+
+class WizardLoadPoweremailTemplate(osv.osv_memory):
+
+    _name = "wizard.load.poweremail.template"
+
+    def load_poweremail_template(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+        wiz = self.browse(cursor, uid, ids[0], context=context)
+        poweremail_template_obj = self.pool.get('poweremail.templates')
+        poweremail_template_source_obj = self.pool.get(
+            'poweremail.templates.source'
+        )
+        res_lang_obj = self.pool.get('res.lang')
+        # Read source ids
+        source_v = poweremail_template_obj.read(
+            cursor, uid, ids[0], ['source_ids'], context=context
+        )
+        source_ids = source_v['source_ids']
+        for source_id in source_ids:
+            template_source_v = poweremail_template_source_obj.read(
+                cursor, uid, source_id, [
+                    'template_id', 'source', 'lang'
+                ],
+                context=context
+            )
+            file_path = "{}/{}".format(
+                config['addons_path'], template_source_v['source']
+            )
+            if os.path.exists(file_path):
+                with open(file_path, "r") as mf:
+                    ctx = context.copy()
+                    res_lang_v = res_lang_obj.read(
+                        cursor, uid, template_source_v['lang'][0], [
+                            'code'
+                        ],
+                        context=context
+                    )
+                    ctx['lang'] = res_lang_v['code']
+                    file_contents = mf.read()
+                    poweremail_template_obj.write(
+                        cursor, uid, template_source_v['template_id'][0], {
+                            'def_body_text': file_contents
+                        },
+                        context=ctx
+                    )
+            else:
+                path_split = file_path.split('/')
+                raise osv.except_osv(
+                    'Error',
+                    'The entered file: {} does not exist'.format(path_split[-1])
+                )
+        return {}
+
+    _columns = {
+        'template_id': fields.many2one(
+            'poweremail.templates', 'Template', select=1, required=True,
+        )
+    }
+
+
+WizardLoadPoweremailTemplate()

--- a/poweremail_load_templates/wizard/wizard_load_poweremail_template.xml
+++ b/poweremail_load_templates/wizard/wizard_load_poweremail_template.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_wizard_load_poweremail_template">
+            <field name="name">wizard.load.poweremail.template</field>
+            <field name="model">wizard.load.poweremail.template</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Load poweremail template">
+                    <group colspan="2">
+                        <field name="template_id" required="1"/>
+                    </group>
+                    <group colspan="4">
+                        <button special="cancel" string="Cancel" icon="gtk-close"/>
+                        <button icon="gtk-ok" name="load_poweremail_template" string="OK" type="object"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_wizard_load_poweremail_template">
+            <field name="name">Load poweremail teamplate</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.load.poweremail.template</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+        <record model="ir.values" id="values_wizard_load_poweremail_template">
+            <field name="object" eval="1"/>
+            <field name="name">Load poweremail teamplate</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">poweremail.templates</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_load_poweremail_template'))"/>
+        </record>
+         <menuitem name="Load poweremail template" id="menuitem_wizard_load_poweremail_template" parent="poweremail.menu_poweremail_templates" action="action_wizard_load_poweremail_template" sequence="10"/>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objetivos

- Añadir nuevo modulo para cargar las plantillas de poweremail usando un asistente

## Comportamiento nuevo

- Asistente que ofrece la posibilidad de cargar las platillas del poweremail

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - poweremail_load_templates
- [x] Migración de datos
    - poweremail_load_templates  5.0.23.9.0

## Checklist

- [x] Test code
