### PR TITLE
Añadir nuevo estado posible de firma digital

### DIFF
--- a/poweremail_signaturit/poweremail_mailbox.py
+++ b/poweremail_signaturit/poweremail_mailbox.py
@@ -97,6 +97,7 @@ class PoweremailMailbox(osv.osv):
             ('email_delivered', _(u"Email enviat")),
             ('email_opened', _(u"Email obert per el receptor")),
             ('email_bounced', _(u"No s'ha pogut enviar el email")),
+            ('bounce', _(u"No s'ha pogut enviar el email")),
             ('certification_completed', 'certification_completed'), # Posem el mateix fins que a la documentació hi hagi alguna cosa
             ('email_deferred', _(u"No s'ha pogut enviar el email, es fara un reintent")),
             ('documents_opened', _(u"Vista previa dels documents del email oberta")),


### PR DESCRIPTION
## Comportamiento antiguo

Cuando la API de signaturit devuelve `bounced` en el estado de la firma digital, la sincronización con el ERP falla puesto que no se tiene en cuenta dicho estado,

## Comportamiento nuevo

La sincronización ya se puede llevar a cabo