### PR TITLE
Plantilla genérica de correo electrónico

### DIFF
--- a/poweremail_generic_template/__terp__.py
+++ b/poweremail_generic_template/__terp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "poweremail_basic_template",
+    "description": """Implements a generic email template using the banners module""",
+    "version": "0-dev",
+    "author": "GISCE",
+    "category": "GISCEMaster",
+    "depends": [
+        "poweremail",
+        "report_banner"
+    ],
+    "init_xml": [],
+    "demo_xml": [],
+    "update_xml": [
+        "data/banners/banner_generic_email_template_title.xml",
+        "data/banners/banner_generic_email_template_header.xml",
+        "data/banners/banner_generic_email_template_preheader.xml",
+        "data/banners/banner_generic_email_template_body.xml",
+        "data/banners/banner_generic_email_template_footer.xml",
+        "data/banners/banner_generic_email_template_css.xml",
+    ],
+    "active": False,
+    "installable": True
+}

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_body.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_body.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_body">
+            <field name="name">Email genérico (TEMPLATE): cuerpo (body)</field>
+            <field name="code">generic_email_template_body</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="end_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye el cuerpo (body) en el email genérico.
+Se debe utilizar como referencia de cómo configurar el banner para un correo en concreto.</field>
+            <field name="html[en_US]" file="emails/generic/components/body/en.mako"/>
+            <field name="html[ca_ES]" file="emails/generic/components/body/ca.mako"/>
+            <field name="html[es_ES]" file="emails/generic/components/body/es.mako"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_css.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_css.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_css">
+            <field name="name">Email genérico: estilos/branding (CSS)</field>
+            <field name="code">generic_email_template_css</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye el estilo/branding (CSS) en el email genérico.</field>
+            <field name="html[en_US]" file="emails/generic/components/style.css"/>
+            <field name="html[ca_ES]" file="emails/generic/components/style.css"/>
+            <field name="html[es_ES]" file="emails/generic/components/style.css"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_footer.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_footer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_footer">
+            <field name="name">Email genérico: pie de correo (footer)</field>
+            <field name="code">generic_email_template_footer</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye el pie de correo (footer) en el email genérico.
+Nota: este componente asume que el objeto tiene el campo "company_id". Si no lo tiene, se debe crear
+otro banner especificando como acceder a dicho campo.</field>
+            <field name="html[en_US]" file="emails/generic/components/footer/en.mako"/>
+            <field name="html[ca_ES]" file="emails/generic/components/footer/en.mako"/>
+            <field name="html[es_ES]" file="emails/generic/components/footer/en.mako"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_header.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_header.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_header">
+            <field name="name">Email genérico: cabecera (header)</field>
+            <field name="code">generic_email_template_header</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye la cabecera (header) en el email genérico.</field>
+            <field name="html[en_US]" file="emails/generic/components/header/en.mako"/>
+            <field name="html[ca_ES]" file="emails/generic/components/header/ca.mako"/>
+            <field name="html[es_ES]" file="emails/generic/components/header/es.mako"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_preheader.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_preheader.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_preheader">
+            <field name="name">Email genérico (TEMPLATE): preheader</field>
+            <field name="code">generic_email_template_preheader</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="end_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye el preheader en el email genérico.
+Se debe utilizar como referencia de cómo configurar el preheader para un correo en concreto.</field>
+            <field name="html[en_US]" file="emails/generic/components/preheader/en.mako"/>
+            <field name="html[ca_ES]" file="emails/generic/components/preheader/ca.mako"/>
+            <field name="html[es_ES]" file="emails/generic/components/preheader/es.mako"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/data/banners/banner_generic_email_template_title.xml
+++ b/poweremail_generic_template/data/banners/banner_generic_email_template_title.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="report.banner" id="banner_generic_email_template_title">
+            <field name="name">Email genérico (TEMPLATE): título (title)</field>
+            <field name="code">generic_email_template_title</field>
+            <field name="start_date">2000-01-01</field>
+            <field name="end_date">2000-01-01</field>
+            <field name="sequence">0</field>
+            <field name="res_model">no.required</field>
+            <field name="description">Componente que constituye el título (title) en el email genérico.
+Se debe utilizar como referencia de cómo configurar el título para un correo en concreto.</field>
+            <field name="html[en_US]" file="emails/generic/components/title/en.mako"/>
+            <field name="html[ca_ES]" file="emails/generic/components/title/ca.mako"/>
+            <field name="html[es_ES]" file="emails/generic/components/title/es.mako"/>
+        </record>
+    </data>
+</openerp>

--- a/poweremail_generic_template/emails/generic/components/body/ca.mako
+++ b/poweremail_generic_template/emails/generic/components/body/ca.mako
@@ -1,0 +1,9 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td>
+      <p>Hello!</p>
+      <p>This an example of the generic email.</p>
+      <p>Kind regards,</p>
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/body/en.mako
+++ b/poweremail_generic_template/emails/generic/components/body/en.mako
@@ -1,0 +1,9 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td>
+      <p>Bon dia!</p>
+      <p>Això és un exemple del correu electrònic genèric.</p>
+      <p>Atentament,</p>
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/body/es.mako
+++ b/poweremail_generic_template/emails/generic/components/body/es.mako
@@ -1,0 +1,9 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td>
+      <p>Hola!</p>
+      <p>Esto es un ejemplo del cuerpo del correo electrónico genérico.</p>
+      <p>Atentamente,</p>
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/footer/en.mako
+++ b/poweremail_generic_template/emails/generic/components/footer/en.mako
@@ -1,0 +1,15 @@
+<% company = object.company_id %>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td class="content-block">
+      <span class="apple-link">${company.partner_id.address[0].street}</span>
+      <br> 📞 ${company.partner_id.address[0].phone} / ${company.partner_id.address[0].mobile}
+      <br> 📨 ${company.partner_id.address[0].email}
+    </td>
+  </tr>
+  <tr>
+    <td class="content-block powered-by">
+      <a href="${company.partner_id.website}">${company.partner_id.name}</a>.
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/header/ca.mako
+++ b/poweremail_generic_template/emails/generic/components/header/ca.mako
@@ -1,0 +1,7 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td class="align-center" width="100%">
+      <img src="https://gisce.net/images/logo.png" height="100" alt="Logo empresa">
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/header/en.mako
+++ b/poweremail_generic_template/emails/generic/components/header/en.mako
@@ -1,0 +1,7 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td class="align-center" width="100%">
+      <img src="https://gisce.net/images/logo.png" height="100" alt="Company logo">
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/header/es.mako
+++ b/poweremail_generic_template/emails/generic/components/header/es.mako
@@ -1,0 +1,7 @@
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td class="align-center" width="100%">
+      <img src="https://gisce.net/images/logo.png" height="100" alt="Logo empresa">
+    </td>
+  </tr>
+</table>

--- a/poweremail_generic_template/emails/generic/components/preheader/ca.mako
+++ b/poweremail_generic_template/emails/generic/components/preheader/ca.mako
@@ -1,0 +1,1 @@
+Preheader no configurado

--- a/poweremail_generic_template/emails/generic/components/preheader/en.mako
+++ b/poweremail_generic_template/emails/generic/components/preheader/en.mako
@@ -1,0 +1,1 @@
+No preheader configured

--- a/poweremail_generic_template/emails/generic/components/preheader/es.mako
+++ b/poweremail_generic_template/emails/generic/components/preheader/es.mako
@@ -1,0 +1,1 @@
+Preheader no configurado

--- a/poweremail_generic_template/emails/generic/components/style.css
+++ b/poweremail_generic_template/emails/generic/components/style.css
@@ -1,0 +1,289 @@
+/* -------------------------------------
+    GLOBAL RESETS
+------------------------------------- */
+/*All the styling goes here*/
+img {
+  border: none;
+  -ms-interpolation-mode: bicubic;
+  max-width: 100%;
+}
+body {
+  background-color: #eaebed;
+  font-family: sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+table {
+  border-collapse: separate;
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+  min-width: 100%;
+  width: 100%; }
+  table td {
+    font-family: sans-serif;
+    font-size: 14px;
+    vertical-align: top;
+}
+/* -------------------------------------
+    BODY & CONTAINER
+------------------------------------- */
+.body {
+  background-color: #eaebed;
+  width: 100%;
+}
+/* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
+.container {
+  display: block;
+  Margin: 0 auto !important;
+  /* makes it centered */
+  max-width: 580px;
+  padding: 10px;
+  width: 580px;
+}
+/* This should also be a block element, so that it will fill 100% of the .container */
+.content {
+  box-sizing: border-box;
+  display: block;
+  Margin: 0 auto;
+  max-width: 580px;
+  padding: 10px;
+}
+/* -------------------------------------
+    HEADER, FOOTER, MAIN
+------------------------------------- */
+.main {
+  background: #ffffff;
+  border-radius: 3px;
+  width: 100%;
+}
+.header {
+  padding: 20px 0;
+}
+.wrapper {
+  box-sizing: border-box;
+  padding: 20px;
+}
+.content-block {
+  padding-bottom: 10px;
+  padding-top: 10px;
+}
+.footer {
+  clear: both;
+  Margin-top: 10px;
+  text-align: center;
+  width: 100%;
+}
+  .footer td,
+  .footer p,
+  .footer span,
+  .footer a {
+    color: #9a9ea6;
+    font-size: 12px;
+    text-align: center;
+}
+/* -------------------------------------
+    TYPOGRAPHY
+------------------------------------- */
+h1,
+h2,
+h3,
+h4 {
+  color: #06090f;
+  font-family: sans-serif;
+  font-weight: 400;
+  line-height: 1.4;
+  margin: 0;
+  margin-bottom: 30px;
+}
+h1 {
+  font-size: 35px;
+  font-weight: 300;
+  text-align: center;
+  text-transform: capitalize;
+}
+p,
+ul,
+ol {
+  font-family: sans-serif;
+  font-size: 14px;
+  font-weight: normal;
+  margin: 0;
+  margin-bottom: 15px;
+}
+  p li,
+  ul li,
+  ol li {
+    list-style-position: inside;
+    margin-left: 5px;
+}
+a {
+  color: #ec0867;
+  text-decoration: underline;
+}
+/* -------------------------------------
+    BUTTONS
+------------------------------------- */
+.btn {
+  box-sizing: border-box;
+  width: 100%; }
+  .btn > tbody > tr > td {
+    padding-bottom: 15px; }
+  .btn table {
+    min-width: auto;
+    width: auto;
+}
+  .btn table td {
+    background-color: #ffffff;
+    border-radius: 5px;
+    text-align: center;
+}
+  .btn a {
+    background-color: #ffffff;
+    border: solid 1px #ec0867;
+    border-radius: 5px;
+    box-sizing: border-box;
+    color: #82A9ED;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0;
+    padding: 12px 25px;
+    text-decoration: none;
+    text-transform: capitalize;
+}
+.btn-primary table td {
+  background-color: #ec0867;
+}
+.btn-primary a {
+  background-color: #6B99E8;
+  border-color: #6B99E8;
+  color: #ffffff;
+}
+/* -------------------------------------
+    OTHER STYLES THAT MIGHT BE USEFUL
+------------------------------------- */
+.last {
+  margin-bottom: 0;
+}
+.first {
+  margin-top: 0;
+}
+.align-center {
+  text-align: center;
+}
+.align-right {
+  text-align: right;
+}
+.align-left {
+  text-align: left;
+}
+.clear {
+  clear: both;
+}
+.mt0 {
+  margin-top: 0;
+}
+.mb0 {
+  margin-bottom: 0;
+}
+.preheader {
+  color: transparent;
+  display: none;
+  height: 0;
+  max-height: 0;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  mso-hide: all;
+  visibility: hidden;
+  width: 0;
+}
+.powered-by a {
+  text-decoration: none;
+}
+hr {
+  border: 0;
+  border-bottom: 1px solid #f6f6f6;
+  Margin: 20px 0;
+}
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+  table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+  }
+  table[class=body] p,
+  table[class=body] ul,
+  table[class=body] ol,
+  table[class=body] td,
+  table[class=body] span,
+  table[class=body] a {
+    font-size: 16px !important;
+  }
+  table[class=body] .wrapper,
+  table[class=body] .article {
+    padding: 10px !important;
+  }
+  table[class=body] .content {
+    padding: 0 !important;
+  }
+  table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+  }
+  table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+  }
+  table[class=body] .btn table {
+    width: 100% !important;
+  }
+  table[class=body] .btn a {
+    width: 100% !important;
+  }
+  table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+  }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+  .ExternalClass {
+    width: 100%;
+  }
+  .ExternalClass,
+  .ExternalClass p,
+  .ExternalClass span,
+  .ExternalClass font,
+  .ExternalClass td,
+  .ExternalClass div {
+    line-height: 100%;
+  }
+  .apple-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+  }
+  .btn-primary table td:hover {
+    background-color: #82A9ED !important;
+  }
+  .btn-primary a:hover {
+    background-color: #82A9ED !important;
+    border-color: #82A9ED !important;
+  }
+}

--- a/poweremail_generic_template/emails/generic/components/title/ca.mako
+++ b/poweremail_generic_template/emails/generic/components/title/ca.mako
@@ -1,0 +1,1 @@
+Títol de l'email

--- a/poweremail_generic_template/emails/generic/components/title/en.mako
+++ b/poweremail_generic_template/emails/generic/components/title/en.mako
@@ -1,0 +1,1 @@
+Email title

--- a/poweremail_generic_template/emails/generic/components/title/es.mako
+++ b/poweremail_generic_template/emails/generic/components/title/es.mako
@@ -1,0 +1,1 @@
+Título del email

--- a/poweremail_generic_template/emails/generic/index.mako
+++ b/poweremail_generic_template/emails/generic/index.mako
@@ -1,0 +1,66 @@
+<!doctype html>
+<%
+from datetime import datetime
+from poweremail.poweremail_template import get_value
+
+pool = object.pool
+cursor = object._cr
+uid = object._uid
+today = datetime.today().date().strftime('%Y-%m-%d')
+
+banner_o = pool.get('report.banner')
+
+banners = banner_o.get_report_banners(
+  cursor, uid, 'poweremail.templates,{}'.format(template.id),
+  today, object.id, context={'lang': lang}
+)
+
+body_html = get_value(cursor, uid, object.id, message=banners['generic_email_template_body'], template=template, context={'lang': lang})
+footer_html = get_value(cursor, uid, object.id, message=banners['generic_email_template_footer'], template=template, context={'lang': lang})
+%>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>${banners['generic_email_template_title']}</title>
+    <style>
+      ${banners['generic_email_template_css']}
+    </style>
+  </head>
+  <body class="">
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+      <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+          <div class="header">${banners['generic_email_template_header']}</div>
+          <div class="content">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <span class="preheader">${banners['generic_email_template_preheader']}</span>
+            <table role="presentation" class="main">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper">
+                  ${body_html}
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                      <td>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- START FOOTER -->
+            <div class="footer">${footer_html}</div>
+            <!-- END FOOTER -->
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td>&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Objetivos

Facilitar la creación y modificación de plantillas de correo electrónico

## Comportamiento antiguo

Actualmente para crear una plantilla de correo se tiene que "crear" (o hacer un copy-paste de una plantilla existente) de cero todo el cuerpo del correo.

Esto no es eficiente ya que si el estilo del correo (_branding_) es común para todas las comunicaciones, el día que se quiera realizar alguna modificación se tendrá que ir plantilla por plantilla realizando las modificaciones pertinentes.

Si en cambio se necesita crear una nueva comunicación, se recurrirá al copy-paste el cual puede dar lugar a error.

## Comportamiento nuevo

Este módulo implementa una plantilla genérica que permite ser fácilmente editable utilizando los banners y los dominios de banners para tener un contenido personalizable por plantilla.

La plantilla genérica esta constituida por 3 banners que son visibles en el contenido del correo:

- `generic_email_template_header`
- `generic_email_template_body`
- `generic_email_template_footer`

![imagen](https://github.com/user-attachments/assets/59537d7d-aae2-4486-a08c-bd4cdbbf0788)

y otros dos que corresponden a "metadatos" del propio correo:

- `generic_email_template_title`: se utiliza como nombre del HTML generado. No se suele mostrar en los correos pero se ha creado para mantener el estándar HTML.
- `generic_email_template_preheader`: algunos clientes de correo utilizan este _tag_ como un asunto que se visualiza desde el listado de correos. Vendría a ser un "asunto resumido"

Un ejemplo de como se puede utilizar esta plantilla la encontraremos en la siguiente pull request: https://github.com/gisce/erp/pull/21041
