### PR TITLE
Correcció login per smtp amb el poweremail_auth

### DIFF
--- a/poweremail_auth/poweremail_core.py
+++ b/poweremail_auth/poweremail_core.py
@@ -47,7 +47,7 @@ class PoweremailCoreAccounts(osv.osv):
                 auth_str = self.generate_oauth_2_string(core_account.email_id, token, base64_encode=False)
                 self.smtp_authentication(smtp_conn, auth_str)
             else:
-                super(PoweremailCoreAccounts, self).login_imap(cursor, uid, core_account, smtp_conn, context=context)
+                super(PoweremailCoreAccounts, self).login_smtp(cursor, uid, core_account, smtp_conn, context=context)
 
     def smtp_authentication(self, smtp_conn, auth_string):
         if config.get('debug_enabled', False):


### PR DESCRIPTION
Quan hi havia el mòdul instalat si el SMTP no tenia configurada la contrasenya al IMAP no fa correctament el login