### PR TITLE
Open related object emails button was in the wizard section instead  in the link section

### DIFF
--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -43,7 +43,7 @@ class PoweremailTemplateReference(osv.osv):
                 'name': _("%s Mail Access") % tmpl.name,
                 'model': src_model,
                 'key': 'action',
-                'key2': 'client_action_multi',
+                'key2': 'client_action_relate',
                 'value': "ir.actions.act_window,%s" % action_id,
                 'object': True,
             }


### PR DESCRIPTION
## Old behaviour

The "open related object emails" button was in the wizard section:

![image](https://github.com/user-attachments/assets/3c0fa88f-2e43-490f-9d5f-a792621bf67a)

![image](https://github.com/user-attachments/assets/f79b7a79-4169-4614-ba83-a6dba6b8b22c)

## New behaviour

The "open related object emails" button is in the link section. Following the previous example:

![image](https://github.com/user-attachments/assets/02d4a2ce-343e-49ff-9163-5f7c943310c9)


