### PR TITLE
Cuando se marcaba el check de "Enviar solamente un correo" se envíaba más de un correo.

### DIFF
--- a/poweremail_oorq/poweremail_send_wizard.py
+++ b/poweremail_oorq/poweremail_send_wizard.py
@@ -30,6 +30,9 @@ class PoweremailSendWizard(osv.osv_memory):
         res = []
         ctx = context.copy()
         j_pool = JobsPool()
+        if wiz['single_email'] and len(context['src_rec_ids']) > 1:
+            # We send a single email for several records
+            context['src_rec_ids'] = context['src_rec_ids'][:1]
         # Copy the original list
         src_rec_ids = context.get('src_rec_ids', [])[:]
         len_src_rec_ids = len(src_rec_ids)


### PR DESCRIPTION
## Comportamiento antiguo

Cuando se marca el check de "Solo un correo electrónico" en el asistente genérico de enviar correos y se seleccionan varios registros:

![image](https://github.com/user-attachments/assets/4243fc62-e7d2-4b3f-8ce8-24ca5e99fca7)

Se genera mas de un correo:

![image](https://github.com/user-attachments/assets/05de4756-06b3-405a-b160-7fba287eef50)

El comportamiento es un tanto especial ya que no genera un correo por registro, si no que los agrupa en parejas.

## Comportamiento nuevo

Ahora solamente genera un correo electrónico:

![image](https://github.com/user-attachments/assets/cf0d2104-febb-4a7d-b6d3-f8b0b0ba96fa)
