### PR TITLE
Mejorar filtro del asistente que muestra los registros de los correos relacionados

### DIFF
--- a/poweremail_references/migrations/5.0.25.9.0/post-0001_update_poweremail_mailbox_related_action.py
+++ b/poweremail_references/migrations/5.0.25.9.0/post-0001_update_poweremail_mailbox_related_action.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import pooler
+from tqdm import tqdm
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    pool = pooler.get_pool(cursor.dbname)
+    uid = 1
+    active_id = 0
+
+    template_o = pool.get('poweremail.templates')
+    template_ids = template_o.search(cursor, uid, [('ref_ir_act_window_access', '!=', False)])
+    for template_id in tqdm(template_ids):
+        template = template_o.simple_browse(cursor, uid, template_id)
+        domain = eval(template.ref_ir_act_window_access.domain)
+        domain.append(('template_id', '=', template.id))
+        domain = str(domain)
+        domain = domain.replace("0'", """%d' % active_id""")
+        sql = """UPDATE ir_act_window SET domain = %s WHERE id = %d"""
+        cursor.execute(sql, (domain, template.ref_ir_act_window_access.id))
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -26,7 +26,7 @@ class PoweremailTemplateReference(osv.osv):
                 'res_model': 'poweremail.mailbox',
                 'src_model': src_model,
                 'view_type': 'form',
-                'domain': ("[('reference','=','{src_model},%d'%active_id),('template_id','=', {model_id})]".format(
+                'domain': ("[('reference', '=', '{src_model},%d' % active_id),('template_id', '=', {model_id})]".format(
                     src_model=src_model,
                     model_id=id
                 )),

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -26,8 +26,10 @@ class PoweremailTemplateReference(osv.osv):
                 'res_model': 'poweremail.mailbox',
                 'src_model': src_model,
                 'view_type': 'form',
-                'domain': ("[('reference','=','" +
-                           src_model + ",%d'%active_id),('template_id','='," + str(id) + ")]"),
+                'domain': ("[('reference','=','{src_model},%d%active_id'),('template_id','=', {model_id})]".format(
+                    src_model=src_model,
+                    model_id=id
+                )),
                 'view_mode': 'tree,form',
             }
             # If already exists, update action, else create it

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -27,7 +27,7 @@ class PoweremailTemplateReference(osv.osv):
                 'src_model': src_model,
                 'view_type': 'form',
                 'domain': ("[('reference','=','" +
-                           src_model + ",%d'%active_id),('template_id','=',id)]"),
+                           src_model + ",%d'%active_id),('template_id','='," + str(id) + ")]"),
                 'view_mode': 'tree,form',
             }
             # If already exists, update action, else create it

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -27,7 +27,7 @@ class PoweremailTemplateReference(osv.osv):
                 'src_model': src_model,
                 'view_type': 'form',
                 'domain': ("[('reference','=','" +
-                           src_model + ",%d'%active_id)]"),
+                           src_model + ",%d'%active_id),('template_id','=',id)]"),
                 'view_mode': 'tree,form',
             }
             # If already exists, update action, else create it

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -26,7 +26,7 @@ class PoweremailTemplateReference(osv.osv):
                 'res_model': 'poweremail.mailbox',
                 'src_model': src_model,
                 'view_type': 'form',
-                'domain': ("[('reference','=','{src_model},%d%active_id'),('template_id','=', {model_id})]".format(
+                'domain': ("[('reference','=','{src_model},%d'%active_id),('template_id','=', {model_id})]".format(
                     src_model=src_model,
                     model_id=id
                 )),


### PR DESCRIPTION
## Objetivos
- Corregir filtro del asistente, ya que para mostrar el registro de  los correos relacionados solo tiene en cuenta que el mail tenga la referencia del registro, cuando también debería tenerlo sobre la plantilla del email.

## Comportamiento antiguo

- El filtro para mostrar el registro solo tiene en cuenta el email
![pre-domain_value](https://github.com/user-attachments/assets/c4ec0c29-f5f5-4f24-a686-9ae3f852430b)


## Comportamiento nuevo

- El domain filtra por el mail que se tiene de referencia y por la plantilla de los emails.
![post-domain_value](https://github.com/user-attachments/assets/3664ed43-e235-458f-b666-808c5ce2e6bc)


## Afectaciones / Migración de datos
- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - poweremail_references
    
## Relacionado

- TASK-71914
- Necesita https://github.com/gisce/poweremail-modules/pull/61