### PR TITLE
Añadir el botón para eliminar el enlace a los correos electrónicos relacionados

### DIFF
--- a/poweremail_references/migrations/5.0.25.5.0/post-0002_add_remove_access_reference_btn.py
+++ b/poweremail_references/migrations/5.0.25.5.0/post-0002_add_remove_access_reference_btn.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import load_data_records
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    load_data_records(
+        cursor,
+        'poweremail_references',
+        'poweremail_template_view.xml',
+        ['poweremail_template_access_form'],
+        mode='update'
+    )
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -60,6 +60,23 @@ class PoweremailTemplateReference(osv.osv):
 
         return True
 
+    def remove_access_reference(self, cursor, uid, ids, context):
+        action_obj = self.pool.get('ir.actions.act_window')
+        value_obj = self.pool.get('ir.values')
+
+        template_brw = self.pool.get('poweremail.templates').browse(cursor, uid, ids[0])
+
+        if template_brw.ref_ir_act_window_access:
+            action_id = template_brw.ref_ir_act_window_access.id
+            template_brw.write({'ref_ir_act_window_access': False})
+            action_obj.unlink(cursor, uid, action_id)
+
+        if template_brw.ref_ir_value_access:
+            value_id = template_brw.ref_ir_value_access.id
+            template_brw.write({'ref_ir_value_access': False})
+            value_obj.unlink(cursor, uid, value_id)
+
+
     _columns = {
         'ref_ir_act_window_access': fields.many2one(
                                         'ir.actions.act_window',

--- a/poweremail_references/poweremail_template_view.xml
+++ b/poweremail_references/poweremail_template_view.xml
@@ -12,7 +12,10 @@
                         <field name="ref_ir_value_access" colspan="4"/>
                         <field name="ref_ir_act_window_access" colspan="4"/>
                         <group>
-                            <label string="" colspan="3"/>
+                            <label string="" colspan="2"/>
+                                <button name="remove_access_reference" colspan="1" string="Remove template emails link" type="object"
+                                    attrs="{'readonly':[('ref_ir_act_window_access', '=', False), ('ref_ir_value_access', '=', False)]}"
+                                    icon="minus" primary="1" danger="1" />
                             <button name="create_access_reference" colspan="1" string="Create template emails link" type="object" icon="plus" primary="1"/>
                         </group>
                     </page>


### PR DESCRIPTION
## Objetivos
- Añadir un botón para eliminar los enlaces de la plantilla de correo

## Comportamiento antiguo
![pre](https://github.com/user-attachments/assets/d3acbb10-2332-489a-92bd-65e7e50afeeb)

## Comportamiento nuevo
Se ha añadido el botón para que elimine la acción y el valor que se crea al hacer servir el botón de «create template emails link».


1. 
![post1](https://github.com/user-attachments/assets/9a5bf810-a8f2-493f-a168-7bac65d42b9d)


2.
![post2](https://github.com/user-attachments/assets/aa70b081-a0a5-4ad1-a8a9-cf1deb88b543)


3.
![post3](https://github.com/user-attachments/assets/b027602f-4ae1-4aca-a126-36bed8659a84)


## Afectaciones / Migración de datos
- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - poweremail_references

