### PR TITLE
Actualizar estado de línea de campaña al fallar envío

### DIFF
--- a/poweremail_campaign/poweremail_campaign_line.py
+++ b/poweremail_campaign/poweremail_campaign_line.py
@@ -87,8 +87,11 @@ class PoweremailCampaignLine(osv.osv):
         # ids -> ids de les linies
         # vals['folder'] -> si hi posa "sent", marcar com a enviada la factura (cridar powermail_write_callback)
         self.poweremail_callback(cursor, uid, ids, 'write', vals, context=context)
-        if vals.get('folder', False) and vals.get('folder', False) == 'sent':
-            self.write(cursor, uid, ids, {'state': 'sent'})
+        if vals.get('folder', False):
+            if vals['folder'] == 'sent':
+                self.write(cursor, uid, ids, {'state': 'sent'})
+            elif vals['folder'] == 'error':
+                self.write(cursor, uid, ids, {'state': 'sending_error'})
 
     def poweremail_unlink_callback(self, cursor, uid, ids, context=None):
         self.poweremail_callback(cursor, uid, ids, 'unlink', context=context)


### PR DESCRIPTION
Corrección de un problema en el flujo de envío de campañas de correo.
Hasta ahora, cuando un correo asociado a una línea de campaña fallaba en el envío, el mensaje se movía a la carpeta `error` pero la línea de campaña no actualizaba su estado, quedando inconsistencias en el cálculo de progreso.

Con este cambio:

Se modifica el método `poweremail_write_callback` para que:
- Si folder = `sent` → la línea pasa a estado `sent`.
- Si folder = `error` → la línea pasa a estado `sending_error`.

Se añade un test unitario que valida el caso de error en el email, en esta caso, por falta de destinatario, asegurando que la línea se actualiza correctamente a `sending_error`.

De esta forma, las campañas reflejan correctamente el estado real de cada línea y se evitan incoherencias en los progresos.