### PR TITLE
Actualización de dependencias y scripts de migración

### DIFF
--- a/poweremail_generic_template/__terp__.py
+++ b/poweremail_generic_template/__terp__.py
@@ -7,7 +7,7 @@
     "category": "GISCEMaster",
     "depends": [
         "poweremail",
-        "report_banner"
+        "report_banner_poweremail"
     ],
     "init_xml": [],
     "demo_xml": [],

--- a/poweremail_generic_template/migrations/5.0.26.1.0/post-0001_install_report_banner_poweremail.py
+++ b/poweremail_generic_template/migrations/5.0.26.1.0/post-0001_install_report_banner_poweremail.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import install_modules
+import pooler
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    cursor.execute(
+        'SELECT * FROM ir_module_module WHERE name=%s AND state=%s',
+        ('report_banner_poweremail', 'uninstalled')
+    )
+    if cursor.fetchone():
+        logger.info('Instal·lem el modul de report_banner_poweremail')
+        install_modules(cursor, 'report_banner_poweremail')
+        logger.info('Instal·lació completada!')
+    else:
+        logger.info(
+            "El mòdul report_banner_poweremail ja està instal·lat o "
+            "no existeix"
+        )
+
+
+def down(cursor, installed_version):
+    pass
+
+migrate = up


### PR DESCRIPTION
## Objetivos

- Actualizar la dependencia del módulo `poweremail_generic_template` para que dependa del nuevo módulo.

## Comportamiento antiguo

- El módulo `poweremail_generic_template` no declaraba dependencia con el nuevo módulo.

## Comportamiento nuevo

- El módulo `poweremail_generic_template` declara explícitamente la dependencia con el nuevo módulo en el fichero `__terp__.py`.
- Se añade un script de migración que instala automáticamente el nuevo módulo cuando `poweremail_generic_template` está presente.

## Afectaciones / Migración de datos

- [ ] Código. Reiniciar servicios
- [X] Migración de datos
    - módulo: poweremail_generic_template
    - versión: 26.1


## Relacionado
- Origen de la tarea: TASK-80631
- Depende de https://github.com/gisce/erp/pull/25848