### PR TITLE
Añadir referencia del modelo al generar email

### DIFF
--- a/poweremail_references/poweremail_template.py
+++ b/poweremail_references/poweremail_template.py
@@ -77,6 +77,15 @@ class PoweremailTemplateReference(osv.osv):
                 template_brw.write({'ref_ir_value_access': False})
                 template_brw.ref_ir_value_access.unlink()
 
+    def _generate_mailbox_item_from_template(self, cursor, user, template, record_id, context=None):
+        mailbox_id = super(PoweremailTemplateReference, self)._generate_mailbox_item_from_template(
+            cursor, user, template, record_id, context=context
+        )
+        mail = self.pool.get('poweremail.mailbox').simple_browse(cursor, user, mailbox_id, context=context)
+        if not mail.reference:
+            mail.write({'reference': '%s,%d' % (template.object_name.model, record_id)}, context=context)
+
+        return mailbox_id
 
     _columns = {
         'ref_ir_act_window_access': fields.many2one(

--- a/poweremail_references/tests/__init__.py
+++ b/poweremail_references/tests/__init__.py
@@ -2,4 +2,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from .test_poweremail_references import *
+from .test_poweremail_references import TestPoweremailReferences
+
+__all__ = ['TestPoweremailReferences']

--- a/poweremail_references/tests/__init__.py
+++ b/poweremail_references/tests/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from .test_poweremail_references import *

--- a/poweremail_references/tests/__init__.py
+++ b/poweremail_references/tests/__init__.py
@@ -3,5 +3,3 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from .test_poweremail_references import TestPoweremailReferences
-
-__all__ = ['TestPoweremailReferences']

--- a/poweremail_references/tests/test_poweremail_references.py
+++ b/poweremail_references/tests/test_poweremail_references.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+from destral import testing
+
+
+class TestPoweremailReferences(testing.OOTestCaseWithCursor):
+
+    def create_account(self):
+        account_obj = self.openerp.pool.get('poweremail.core_accounts')
+
+        return account_obj.create(self.cursor, self.uid, {
+            'name': 'Test account',
+            'user': self.uid,
+            'email_id': 'test@example.com',
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'smtpuname': 'test',
+            'smtppass': 'test',
+            'company': 'yes',
+        })
+
+    def create_template(self):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        template_obj = self.openerp.pool.get('poweremail.templates')
+
+        model_partner = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'base', 'model_res_partner'
+        )[1]
+
+        return template_obj.create(self.cursor, self.uid, {
+            'name': 'Reference test template',
+            'object_name': model_partner,
+            'enforce_from_account': self.create_account(),
+            'template_language': 'mako',
+            'def_to': 'test@example.com',
+        })
+
+    def test_generated_mailbox_gets_reference_from_template_model(self):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+        template_obj = self.openerp.pool.get('poweremail.templates')
+
+        partner_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'base', 'res_partner_asus'
+        )[1]
+        template_id = self.create_template()
+        template = template_obj.browse(self.cursor, self.uid, template_id)
+
+        mailbox_id = template_obj._generate_mailbox_item_from_template(
+            self.cursor, self.uid, template, partner_id, context={}
+        )
+
+        mailbox = mailbox_obj.read(
+            self.cursor, self.uid, mailbox_id, ['reference']
+        )
+        self.assertEqual(
+            mailbox['reference'], 'res.partner,%d' % partner_id
+        )

--- a/poweremail_references/tests/test_poweremail_references.py
+++ b/poweremail_references/tests/test_poweremail_references.py
@@ -4,54 +4,38 @@ from destral import testing
 
 class TestPoweremailReferences(testing.OOTestCaseWithCursor):
 
-    def create_account(self):
-        account_obj = self.openerp.pool.get('poweremail.core_accounts')
-
-        return account_obj.create(self.cursor, self.uid, {
-            'name': 'Test account',
-            'user': self.uid,
-            'email_id': 'test@example.com',
-            'smtpserver': 'smtp.example.com',
-            'smtpport': 587,
-            'smtpuname': 'test',
-            'smtppass': 'test',
-            'company': 'yes',
-        })
-
-    def create_template(self):
+    def get_demo_template(self):
         imd_obj = self.openerp.pool.get('ir.model.data')
         template_obj = self.openerp.pool.get('poweremail.templates')
 
-        model_partner = imd_obj.get_object_reference(
-            self.cursor, self.uid, 'base', 'model_res_partner'
+        template_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'poweremail',
+            'default_template_poweremail'
         )[1]
+        account_id = imd_obj.get_object_reference(
+            self.cursor, self.uid, 'poweremail',
+            'info_energia_from_email'
+        )[1]
+        template_obj.write(
+            self.cursor, self.uid, template_id,
+            {'enforce_from_account': account_id}
+        )
 
-        return template_obj.create(self.cursor, self.uid, {
-            'name': 'Reference test template',
-            'object_name': model_partner,
-            'enforce_from_account': self.create_account(),
-            'template_language': 'mako',
-            'def_to': 'test@example.com',
-        })
+        return template_obj.browse(self.cursor, self.uid, template_id)
 
     def test_generated_mailbox_gets_reference_from_template_model(self):
-        imd_obj = self.openerp.pool.get('ir.model.data')
         mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
         template_obj = self.openerp.pool.get('poweremail.templates')
 
-        partner_id = imd_obj.get_object_reference(
-            self.cursor, self.uid, 'base', 'res_partner_asus'
-        )[1]
-        template_id = self.create_template()
-        template = template_obj.browse(self.cursor, self.uid, template_id)
+        template = self.get_demo_template()
 
         mailbox_id = template_obj._generate_mailbox_item_from_template(
-            self.cursor, self.uid, template, partner_id, context={}
+            self.cursor, self.uid, template, self.uid, context={}
         )
 
         mailbox = mailbox_obj.read(
             self.cursor, self.uid, mailbox_id, ['reference']
         )
         self.assertEqual(
-            mailbox['reference'], 'res.partner,%d' % partner_id
+            mailbox['reference'], 'res.users,%d' % self.uid
         )


### PR DESCRIPTION
#### Objetivo
Al generar un email, se debe añadir el modelo de referéncia en este.

#### Comportamiento antiguo
No se añadia la referencia al modelo si se creaba el email sin el context de src_rec_id y src_model.

#### Comportamiento nuevo
Se añade la referencia al modelo al crear el email.

#### Acciones
- [x] Reiniciar render de poweremail queue.